### PR TITLE
Connect projects to .NET Aspire

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,5 +13,7 @@
     <PackageVersion Include="Shiny.Mediator" Version="4.7.0-beta-0021" />
     <PackageVersion Include="Microsoft.Kiota.Bundle" Version="1.19.0" />
     <PackageVersion Include="Microsoft.Kiota.Cli.Commons" Version="1.1.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.0.0-preview.4" />
+    <PackageVersion Include="Aspire.Dashboard" Version="9.0.0-preview.4" />
   </ItemGroup>
 </Project>

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" />
+    <PackageReference Include="Aspire.Dashboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WebApi\WebApi.csproj" />
+    <ProjectReference Include="..\UnoApp\UnoApp\UnoApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,0 +1,10 @@
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject("webapi", "../WebApi/WebApi.csproj");
+
+builder.AddProject("unoapp", "../UnoApp/UnoApp/UnoApp.csproj")
+       .WithReference(api);
+
+builder.Build().Run();

--- a/src/UnoApp/UnoApp.sln
+++ b/src/UnoApp/UnoApp.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixApi", "..\External\WixAp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "..\WebApi\WebApi.csproj", "{D144B7B1-F73E-4FCA-981E-0085808205F2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "..\AppHost\AppHost.csproj", "{D8C59AAE-8F41-49AF-8873-DB421FA60A3B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,11 +46,15 @@ Global
 		{65B19D79-BF60-5013-6C5E-5CD2EE409288}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65B19D79-BF60-5013-6C5E-5CD2EE409288}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65B19D79-BF60-5013-6C5E-5CD2EE409288}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D144B7B1-F73E-4FCA-981E-0085808205F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D144B7B1-F73E-4FCA-981E-0085808205F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D144B7B1-F73E-4FCA-981E-0085808205F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D144B7B1-F73E-4FCA-981E-0085808205F2}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {D144B7B1-F73E-4FCA-981E-0085808205F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D144B7B1-F73E-4FCA-981E-0085808205F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D144B7B1-F73E-4FCA-981E-0085808205F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D144B7B1-F73E-4FCA-981E-0085808205F2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D8C59AAE-8F41-49AF-8873-DB421FA60A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D8C59AAE-8F41-49AF-8873-DB421FA60A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D8C59AAE-8F41-49AF-8873-DB421FA60A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D8C59AAE-8F41-49AF-8873-DB421FA60A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,4 +1,6 @@
 
+using Aspire.Hosting;
+
 namespace WebApi
 {
     public class Program
@@ -7,8 +9,9 @@ namespace WebApi
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            // Add services to the container.
+            builder.AddServiceDefaults();
 
+            // Add services to the container.
             builder.Services.AddControllers();
             // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
             builder.Services.AddOpenApi();
@@ -21,6 +24,7 @@ namespace WebApi
                 app.MapOpenApi();
             }
 
+            app.MapDefaultEndpoints();
             app.UseHttpsRedirection();
 
             app.UseAuthorization();

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi"  />
+    <PackageReference Include="Aspire.Hosting" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Aspire AppHost project running WebApi and UnoApp
- wire WebApi to Aspire service defaults
- reference Aspire packages via central management
- include AppHost in the UnoApp solution

## Testing
- `dotnet test ./src/UnoApp/UnoApp.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e4061c870832c8c492ca966abfbcb