### PR TITLE
Replace Shiny.Mediator.Uno package with submodule reference

### DIFF
--- a/src/UnoApp/Directory.Packages.props
+++ b/src/UnoApp/Directory.Packages.props
@@ -2,7 +2,4 @@
   <Import Project="..\..\Directory.Packages.props" Condition="exists('..\..\Directory.Packages.props')" />
   <ItemGroup>
   </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Shiny.Mediator.Uno" Version="4.7.0" />
-  </ItemGroup>
 </Project>

--- a/src/UnoApp/UnoApp/UnoApp.csproj
+++ b/src/UnoApp/UnoApp/UnoApp.csproj
@@ -51,11 +51,11 @@
   </PropertyGroup>
   <ItemGroup>
       <!--<MediatorHttp Include="WebApi.json" Namespace="UnoApp.ApiClient" ContractPrefix="optional" ContractPostfix="HttpRequest" Visible="false" />-->
-    <PackageReference Include="Shiny.Mediator.Uno" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\External\WixApi\WixApi.csproj" />
     <ProjectReference Include="..\..\SharedModels\SharedModels.csproj" />
+    <ProjectReference Include="..\..\..\submodules\mediator\src\Shiny.Mediator.Uno\Shiny.Mediator.Uno.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Page Update="Presentation\Pages\WixContacts\WixContactsPage.xaml">


### PR DESCRIPTION
## Summary
- Replaced Shiny.Mediator.Uno NuGet package reference with direct project reference to the mediator submodule
- This enables local development and modifications of the mediator library

## Changes
- Removed `PackageReference` to Shiny.Mediator.Uno from UnoApp.csproj
- Added `ProjectReference` to the mediator submodule at `..\..\..\submodules\mediator\src\Shiny.Mediator.Uno\Shiny.Mediator.Uno.csproj`
- Removed package version entry from Directory.Packages.props

## Test plan
- [x] Project references resolve correctly
- [ ] Build succeeds with the new project reference
- [ ] Application functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)